### PR TITLE
change the defn of `__query_result_or_t` to not require `_Query` to be complete

### DIFF
--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -427,7 +427,7 @@ _CCCL_GLOBAL_CONSTANT __detail::__query_or_t __query_or{};
 
 template <class _Env, class _Query, class _Default>
 using __query_result_or_t _CCCL_NODEBUG_ALIAS =
-  decltype(__query_or(_CUDA_VSTD::declval<_Env>(), _Query{}, _CUDA_VSTD::declval<_Default>()));
+  decltype(__query_or(_CUDA_VSTD::declval<_Env>(), _CUDA_VSTD::declval<_Query>(), _CUDA_VSTD::declval<_Default>()));
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 


### PR DESCRIPTION
## Description

if the type alias `__query_result_or_t` is used within the definition of the query object itself, as #5096 does, the result is a hard compile error. `__query_result_or_t` is currently defined as:

```c++
template <class _Env, class _Query, class _Default>
using __query_result_or_t _CCCL_NODEBUG_ALIAS =
  decltype(__query_or(_CUDA_VSTD::declval<_Env>(), _Query{}, _CUDA_VSTD::declval<_Default>()));
```

for a query defined like:

```c++
struct my_query_t
{
  template <class Env>
  auto operator()(Env const& env) const
    -> __query_result_or_t<Env, my_query_t, some_fallback_t>;
};
```

the type `my_query_t` is indirectly being used before it is complete, by the `_Query{}` expression in the defn of `__query_result_or_t`.

this pr fixes the problem by using `declval<_Query>()` instead of `_Query{}`.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
